### PR TITLE
SLING-7351 include 'META-INF/maven/dependencies.properties' in generated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,11 @@
                             </Bundle-DocURL>
                             <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
                             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                            <!-- Also include the "META-INF/maven/dependencies.properties" file being generated from depends-maven-plugin (used by pax exam) in the resulting JAR if it exists.
+                                 This is necessary as the maven-failsafe-plugin uses the final JAR as classpath when executing ITs (https://issues.apache.org/jira/browse/SUREFIRE-855).
+                                 ITs based on Pax Exam rely on the file "dependencies.properties" in the classpath when setting up the container.
+                             -->
+                            <Include-Resource>META-INF/maven/dependencies.properties=-${project.build.outputDirectory}/META-INF/maven/dependencies.properties,{maven-resources}</Include-Resource>
                         </instructions>
                     </configuration>
                     <executions>


### PR DESCRIPTION
bundle (in case it does exist below 'target/classes')

This file is being referenced from ITs leveraging pax exam and must be
accessible from the classpath of the maven-failsafe-plugin (which
changed with 2.19, due to
https://issues.apache.org/jira/browse/SUREFIRE-855)