### PR TITLE
SLING-8199 - Allow building for Java 10, 11 and 12

### DIFF
--- a/sling-bundle-parent/pom.xml
+++ b/sling-bundle-parent/pom.xml
@@ -168,23 +168,6 @@ Bundle-Category: sling
                             </rules>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>enforce-java</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <!-- Require Java 8 or higher for building (as bnd since version 4.0 only supports Java 8, https://github.com/bndtools/bnd/wiki/Changes-in-4.0.0) -->
-                                <requireJavaVersion>
-                                    <message>
-                                        Apache Sling must be compiled with Java 8 or higher as the bnd-maven-plugin requires that.
-                                    </message>
-                                    <version>1.8.0</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -124,7 +124,7 @@
                                     <property>sling.java.version</property>
                                     <regex>^(8|9|1[0-9])$</regex>
                                     <regexMessage>
-                                        The value of the "sling.java.version" property should comply with the following rule: ^(8|9|1[0-9])$.
+                                        The value of the "sling.java.version" property should comply with the following pattern: ^(8|9|1[0-9])$.
                                     </regexMessage>
                                 </requireProperty>
                             </rules>

--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -49,10 +49,11 @@
         <!--
             Java API and class file compliance. This property supports
             one of three values:
-              - 6: Java 6
-              - 7: Java 7
               - 8: Java 8 (default)
               - 9: Java 9
+              - 10: Java 10
+              - 11: Java 11
+              - 12: Java 12
         -->
         <sling.java.version>8</sling.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -118,13 +119,29 @@
                           <goal>enforce</goal>
                         </goals>
                         <configuration>
-                          <rules>
-                            <requireProperty>
-                              <property>sling.java.version</property>
-                              <regex>[6-9]</regex>
-                              <regexMessage>The property "sling.java.version" may only have one of the following values: 6, 7, 8 or 9.</regexMessage>
-                            </requireProperty>
-                          </rules>
+                            <rules>
+                                <requireProperty>
+                                    <property>sling.java.version</property>
+                                    <regex>^(8|9|1[0-9])$</regex>
+                                    <regexMessage>
+                                        The value of the "sling.java.version" property should conform to the following rule: ^(8|9|1[0-9])$.
+                                    </regexMessage>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                    <message>Apache Sling must be compiled with Java 8 or higher.</message>
+                                </requireJavaVersion>
+                            </rules>
                         </configuration>
                     </execution>
                     <execution>

--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -124,7 +124,7 @@
                                     <property>sling.java.version</property>
                                     <regex>^(8|9|1[0-9])$</regex>
                                     <regexMessage>
-                                        The value of the "sling.java.version" property should conform to the following rule: ^(8|9|1[0-9])$.
+                                        The value of the "sling.java.version" property should comply with the following rule: ^(8|9|1[0-9])$.
                                     </regexMessage>
                                 </requireProperty>
                             </rules>


### PR DESCRIPTION
* dropped support for building Sling with Java < 1.8
* extended support for sling.java.version to allow Java >= 1.8