### PR TITLE
Update pom.xml

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -1067,7 +1067,7 @@
         <pluginRepository>
             <id>apache.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://repository.apache.org/snapshots</url>
+            <url>https://repository.apache.org/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
Download plugins via https only.

There has been a recent mail warning via the ASF security team to only rely on https instead of http when accessing maven repositories.