### PR TITLE
SLING-8369: Update pom.xml to use https only

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -1067,7 +1067,7 @@
         <pluginRepository>
             <id>apache.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://repository.apache.org/snapshots</url>
+            <url>https://repository.apache.org/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
Download plugins via https instead of http.