### PR TITLE
SLING-11337 enable Matomo web analytics for Maven generated sites

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -276,6 +276,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <configuration>
+                        <relativizeDecorationLinks>false</relativizeDecorationLinks><!-- leave absolute URLs untouched, like image urls in header: https://maven.apache.org/plugins/maven-site-plugin/site-mojo.html#relativizeDecorationLinks -->
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>maven-jspc-plugin</artifactId>
                     <version>2.0.8</version>

--- a/sling-parent/src/site/site.xml
+++ b/sling-parent/src/site/site.xml
@@ -24,7 +24,7 @@ under the License.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.9</version>
+        <version>1.11.0</version>
     </skin>
     <version position="right"/>
     <publishDate position="right"/>
@@ -32,8 +32,8 @@ under the License.
         <name>Apache Sling</name>
         <src>https://sling.apache.org/res/logos/sling.svg</src>
         <href>https://sling.apache.org/</href>
-        <height>63</height>
-        <width>123</width>
+        <height>63px</height>
+        <width>123px</width>
     </bannerLeft>
     <bannerRight>
         <name>Apache</name>
@@ -46,6 +46,11 @@ under the License.
             <item name="Apache Sling" href="https://sling.apache.org/"/>
             <item name="Maven Plugins" href="https://sling.apache.org/components/"/>
         </breadcrumbs>
+        <footer><![CDATA[
+<p>&#169; $date.get('yyyy')
+<a href="https://www.apache.org/">The Apache Software Foundation</a> &vert; <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a>
+</p>
+       ]]></footer>
     </body>
     <custom>
         <fluidoSkin>
@@ -56,5 +61,14 @@ under the License.
               <ribbonColor>gray</ribbonColor>
             </gitHub>
         </fluidoSkin>
+        <matomo>
+            <siteId>6</siteId>
+            <url>https://analytics.apache.org</url>
+            <options>
+                <disableCookies/>
+                <trackPageView/>
+                <enableLinkTracking/>
+            </options>
+        </matomo>
     </custom>
 </project>


### PR DESCRIPTION
Upgrade to newest maven-fluido-skin 1.11.0
Make header images work locally (by no longer relativizing URLs)