### PR TITLE
SLING-11411 remove scope from depMgmt

### DIFF
--- a/sling-bundle-parent/pom.xml
+++ b/sling-bundle-parent/pom.xml
@@ -212,14 +212,12 @@ Bundle-DocURL: https://sling.apache.org
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.core</artifactId>
                 <version>7.0.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- Compendium R6 -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.cmpn</artifactId>
                 <version>7.0.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- individual OSGi spec API artifacts (preferred) -->
             <!-- Framework 1.9, Core R7 (https://docs.osgi.org/javadoc/osgi.core/7.0.0/org/osgi/framework/package-summary.html) -->
@@ -227,14 +225,12 @@ Bundle-DocURL: https://sling.apache.org
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.framework</artifactId>
                 <version>1.9.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- Tracker 1.5, Core R7 (https://docs.osgi.org/javadoc/osgi.core/7.0.0/org/osgi/util/tracker/package-summary.html) -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.util.tracker</artifactId>
                 <version>1.5.4</version>
-                <scope>provided</scope>
             </dependency>
             <!-- Data Transfer Object 1.1, Core R7 (https://docs.osgi.org/javadoc/osgi.core/7.0.0/org/osgi/dto/package-summary.html) -->
             <dependency>
@@ -259,7 +255,6 @@ Bundle-DocURL: https://sling.apache.org
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.cm</artifactId>
                 <version>1.6.1</version>
-                <scope>provided</scope>
             </dependency>
             <!-- Service Component 1.4, Compendium R7 (https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/component/package-frame.html) -->
             <!-- and component property types (https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/component/propertytypes/package-frame.html) -->
@@ -267,7 +262,6 @@ Bundle-DocURL: https://sling.apache.org
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.component</artifactId>
                 <version>1.4.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- Event Admin 1.4, Compendium R7 (https://docs.osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/event/package-summary.html) -->
             <dependency>
@@ -282,35 +276,30 @@ Bundle-DocURL: https://sling.apache.org
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.annotation.versioning</artifactId>
                 <version>1.1.2</version>
-                <scope>provided</scope>
             </dependency>
             <!-- https://osgi.org/javadoc/osgi.annotation/7.0.0/org/osgi/annotation/bundle/package-frame.html -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.annotation.bundle</artifactId>
                 <version>1.0.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/component/annotations/package-frame.html -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.component.annotations</artifactId>
                 <version>1.4.0</version>
-                <scope>provided</scope>
             </dependency>
             <!-- https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/metatype/annotations/package-frame.html -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.metatype.annotations</artifactId>
                 <version>1.4.1</version>
-                <scope>provided</scope>
             </dependency>
             <!-- https://sling.apache.org/apidocs/sling11/org/apache/sling/servlets/annotations/package-summary.html -->
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.servlets.annotations</artifactId>
                 <version>1.2.6</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -111,11 +111,18 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>maven-enforcer-rules</artifactId>
+                        <version>1.1.0</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                      <execution>
                         <id>enforce-sling-java-version</id>
                         <goals>
-                          <goal>enforce</goal>
+                            <goal>enforce</goal>
                         </goals>
                         <configuration>
                             <rules>
@@ -126,6 +133,18 @@
                                         The value of the "sling.java.version" property should comply with the following pattern: ^(8|9|1[0-9])$.
                                     </regexMessage>
                                 </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- all local dependencies must have an explicit scope set, https://github.com/apache/sling-maven-enforcer-rules/blob/master/README.md#require-explicit-dependency-scope-since-version-110 -->
+                        <id>enforce-explicit-scope</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireExplicitDependencyScope implementation="org.apache.sling.maven.enforcer.RequireExplicitDependencyScope" />
                             </rules>
                         </configuration>
                     </execution>
@@ -942,7 +961,6 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- Dependency injection annotations -->
@@ -950,7 +968,6 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- JCR API -->
@@ -958,7 +975,6 @@
                 <groupId>javax.jcr</groupId>
                 <artifactId>jcr</artifactId>
                 <version>2.0</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- Basic Logging -->
@@ -966,7 +982,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.25</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- JetBrains annotations for null-analysis (SLING-7798), https://github.com/JetBrains/java-annotations -->
@@ -974,7 +989,6 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>23.0.0</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- Annotations used in Maven Plugins -->
@@ -982,7 +996,6 @@
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven.plugin.tools.version}</version>
-                <scope>provided</scope> <!-- annotations are not used at runtime because @Retention(value=CLASS), they are needed only to build the plugin -->
             </dependency>
 
             <!-- Basic dependencies for Unit Tests -->
@@ -990,13 +1003,11 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>1.7.25</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
enforce explicit scope for all local dependencies via Maven Enforcer
rule

Still a draft as it requires a new release of Sling Maven Enforcer Rules (SLING-11410)