### PR TITLE
SLING-11842 Drop Java 8 as build JDK

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -57,11 +57,15 @@
               - 10..19: Java 10-19
         -->
         <sling.java.version>11</sling.java.version>
+        <!-- release sets API classpath, source and target, see 
+             https://docs.oracle.com/javase/9/tools/javac.htm#GUID-AEEC9F07-CB49-4E96-8BC7-BCC2C7F725C9__GUID-D343F6B4-3FDD-43A8-AD24-43DD70214471 
+             and http://openjdk.java.net/jeps/247, this affects m-compiler-p and m-javadoc-p -->
+        <maven.compiler.release>${sling.java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire.version>3.0.0-M5</surefire.version>
         <minimalMavenBuildVersion>3.3.9</minimalMavenBuildVersion>
-        <minimalJavaBuildVersion>1.8</minimalJavaBuildVersion>
+        <minimalJavaBuildVersion>11</minimalJavaBuildVersion><!-- Parameter "maven.compiler.release" requires JDK9+ and we generally only support LTS releases -->
         <!-- the github id used for the ribbon for Maven sites: https://maven.apache.org/skins/maven-fluido-skin/#GitHub_ribbons -->
         <github.project.id>apache/sling-dummyproject</github.project.id>
         <javadoc.excludePackageNames>*.impl:*.internal:${site.javadoc.exclude}</javadoc.excludePackageNames>
@@ -463,55 +467,6 @@
                     </plugins>
                 </pluginManagement>
             </build>
-        </profile>
-
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <!-- this affects m-compiler-p and m-javadoc-p -->
-                <maven.compiler.source>${sling.java.version}</maven.compiler.source>
-                <maven.compiler.target>${sling.java.version}</maven.compiler.target>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-maven-plugin</artifactId>
-                        <version>1.21</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java18</artifactId>
-                                <version>1.0</version>
-                            </signature>
-                        </configuration>
-                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk9-or-higher</id>
-            <activation>
-                <!-- syntax according to http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html -->
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                 <!-- 
-                 release sets API classpath, source and target, see 
-                 https://docs.oracle.com/javase/9/tools/javac.htm#GUID-AEEC9F07-CB49-4E96-8BC7-BCC2C7F725C9__GUID-D343F6B4-3FDD-43A8-AD24-43DD70214471 
-                 and http://openjdk.java.net/jeps/247, this affects m-compiler-p and m-javadoc-p -->
-                <maven.compiler.release>${sling.java.version}</maven.compiler.release>
-            </properties>
         </profile>
         <!-- This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
         <profile>


### PR DESCRIPTION
We can still target/built for Java 8 with newer JDKs