### PR TITLE
SLING-12485 Update spotless to accept all line endings

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -258,7 +258,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.43.0</version>
+                    <version>2.44.0.BETA4</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -444,6 +444,8 @@
                             <file>config/maven-header-plain.txt</file>
                         </licenseHeader>
                     </java>
+                    <!-- accept all endings to support validations on top of source archives -->
+                    <lineEndings>PRESERVE</lineEndings>
                     <pom>
                         <sortPom>
                             <expandEmptyElements>false</expandEmptyElements>


### PR DESCRIPTION
This is required to run spotless:check on top of extracted source archives (outside Git repositories).
Compare with https://github.com/apache/maven-parent/issues/205 and https://github.com/diffplug/spotless/issues/2277.