### PR TITLE
SLING-12892 update dependency management versions for SLING-10000

### DIFF
--- a/sling-parent/pom.xml
+++ b/sling-parent/pom.xml
@@ -119,6 +119,7 @@
         <!-- the github id used for the ribbon for Maven sites: https://maven.apache.org/skins/maven-fluido-skin/#GitHub_ribbons -->
         <github.project.id>apache/sling-dummyproject</github.project.id>
         <javadoc.excludePackageNames>*.impl:*.internal:${site.javadoc.exclude}</javadoc.excludePackageNames>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -128,7 +129,17 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.1.0</version>
+                <version>4.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>6.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.http.wrappers</artifactId>
+                <version>6.1.0</version>
             </dependency>
 
             <!-- Dependency injection annotations -->
@@ -149,7 +160,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <!-- JetBrains annotations for null-analysis (SLING-7798), https://github.com/JetBrains/java-annotations -->
@@ -168,7 +179,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
Per discussion at: https://lists.apache.org/thread/vzx1nybbfwnvvgb394nthzovbwvp4cy5

bump javax.servlet-api to version 4.0.1

bump slf4j.* to version 2.0.17

define jakarta.servlet-api as version 6.1.0 

define org.apache.felix.http.wrappers as version 6.1.0